### PR TITLE
Fixed delay in background

### DIFF
--- a/lib/jquery-backward-timer.src.js
+++ b/lib/jquery-backward-timer.src.js
@@ -32,6 +32,7 @@
         , plugin = this
 
         plugin.seconds_left = 0
+        plugin.final_hour = Math.floor(Date.now()) + 5
         plugin.target = $(element)
         plugin.timeout = undefined
         plugin.settings = {}
@@ -71,6 +72,7 @@
                 }
             }
             , reset: function() {
+                plugin.final_hour = parseInt(plugin.settings.seconds) + Math.floor(Date.now())
                 plugin.seconds_left = plugin.settings.seconds
                 plugin.methods._render_seconds()
             }
@@ -94,7 +96,7 @@
                         var step = plugin.settings.step
                     }
 
-                    plugin.seconds_left -= step
+                    plugin.seconds_left = (plugin.final_hour - Math.floor(Date.now()))
 
                     var interval = step * 1000
                     plugin.timeout = setTimeout(plugin.methods._on_tick,


### PR DESCRIPTION
While in background, the setTimeOut function is not reliable, and adds a delay over time.